### PR TITLE
Add each_page method for traversing collections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    giant_bomb_api (0.1)
+    giant_bomb_api (0.5.2)
       activesupport
       faraday
       faraday_middleware
@@ -10,11 +10,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.4)
+    activesupport (5.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     byebug (3.5.1)
       columnize (~> 0.8)
@@ -24,17 +23,17 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     columnize (0.9.0)
+    concurrent-ruby (1.0.5)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    faraday (0.9.1)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    i18n (0.7.0)
-    json (1.8.3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    i18n (0.8.4)
     method_source (0.8.2)
-    minitest (5.8.0)
+    minitest (5.10.2)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     pry (0.10.1)
@@ -45,7 +44,7 @@ GEM
       byebug (~> 3.4)
       pry (~> 0.10)
     rake (10.1.1)
-    require_all (1.3.2)
+    require_all (1.4.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -64,9 +63,9 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timecop (0.7.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -79,3 +78,6 @@ DEPENDENCIES
   rake (~> 10.1.0)
   rspec (~> 3.0)
   timecop
+
+BUNDLED WITH
+   1.13.7

--- a/README.md
+++ b/README.md
@@ -117,16 +117,28 @@ You can also directly query a resource that has a collection-endpoint.
 
 This is available for all resources that the [Giantbomb API](http://www.giantbomb.com/api/documentation) offers a 'collection' for. e.g. `game` and `games`or `character` and `characters`.
 
-e.g. all:
+Use the `each_page` method to iterate through each page of a collection. `each_page` will accept a block and pass it the current page of results.
 
-```
-GiantBombApi::Resource::Game.all
+```ruby
+GiantBombApi::Resource::Game.each_page do |page|
+  names = page.results.map(&:name)
+  puts names
+end
 ```
 
-this call supports optional sorting, e.g.:
+`each_page` accepts the following optional keyword arguments:
 
-```
-GiantBombApi::Resource::Game.all(sort: { name: :desc })
+- `sort`: a sort option for the results
+- `limit`: the number of results to return per page. Defaults to 100 (the max allowed through the Giant Bomb API)
+- `offset`: defaults to 0
+- `should_rate_limit`: pass this in as true if you want to ensure that you are rate limiting your requests to under the required 200 per resource per hour (which is important if you're trying to iterate through every page of a resource)
+
+Example using the optional arguments:
+
+```ruby
+GiantBombApi::Resource::Game.each_page(sort: { name: :desc }, limit: 50, should_rate_limit: true) do |page|
+  # do something with the page
+end
 ```
 
 if you want to get more detailed your can do: 

--- a/giant_bomb_api.gemspec
+++ b/giant_bomb_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                      = "giant_bomb_api"
-  s.version                   = "0.5.1"
+  s.version                   = "0.5.2"
   s.default_executable        = "giantbomb"
 
   s.authors                   = ["Tim Adler"]

--- a/lib/giant_bomb_api/collection_resource.rb
+++ b/lib/giant_bomb_api/collection_resource.rb
@@ -12,8 +12,13 @@ module GiantBombApi
       self.instance_variable_get("@collection_resource_name") || self.resource_name.pluralize
     end
 
-    def all(sort = {})
-      where(sort: sort)
+    def each_page(sort: {}, limit: 100, offset: 0, should_rate_limit: false)
+      rate_limit(should_rate_limit) do
+        response = where(sort: sort, limit: limit, offset: offset, tries: 5)
+        yield response
+        offset += limit
+        break unless response.has_more_results?
+      end
     end
 
     def find(id, params = {})
@@ -26,6 +31,7 @@ module GiantBombApi
       sort = params[:sort]
       limit = params[:limit]
       offset = params[:offset]
+      tries ||= (params[:tries] || 0)
 
       args = {}
       args[:filter] = params.reject {|key,value| %i(sort limit offset).include?(key) }
@@ -34,6 +40,41 @@ module GiantBombApi
       args[:offset] = offset if offset.present?
 
       GiantBombApi.client.send_request(Request::Collection.new(self, args))
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+      if (tries -= 1) > 0
+        sleep 5
+        retry
+      end
+
+      raise e
+    end
+
+    private
+
+    def rate_limit(should_rate_limit, &block)
+      started_at = Time.now
+      num_of_requests = 0
+
+      loop do
+        t1 = Time.now
+        block.call
+        num_of_requests += 1
+        t2 = Time.now
+
+        if should_rate_limit
+          if t2 - started_at >= 1.hour
+            started_at = Time.now
+            num_of_requests = 0
+          end
+
+          request_time = t2 - t1
+          time_to_one_hour = (started_at + 1.hour) - t2
+          remaining_requests = 200 - num_of_requests
+          min_time_per_request = time_to_one_hour / remaining_requests
+
+          sleep(min_time_per_request - request_time) if request_time < min_time_per_request
+        end
+      end
     end
 
   end


### PR DESCRIPTION
First off, thanks for the gem! I've been having fun using it to tinker around with the Giant Bomb API.

This adds an `each_page` iterator method that will iterate through all pages in a collection. It accepts a block and will pass the current page to it. It also allows you to optionally rate limit the calls to keep you in compliance with the 200 requests / hour limit.

I also removed the `all` method, since I feel like this should replace that. That method only seemed to work for returning the first page of results in a collection, as it did not accept an `offset` parameter.