### PR TITLE
Update Giant Bomb API URL and add a rate_per_hour option to each_page

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ end
 - `limit`: the number of results to return per page. Defaults to 100 (the max allowed through the Giant Bomb API)
 - `offset`: defaults to 0
 - `should_rate_limit`: pass this in as true if you want to ensure that you are rate limiting your requests to under the required 200 per resource per hour (which is important if you're trying to iterate through every page of a resource)
+- `rate_per_hour`: defaults to 200 (the standard Giant Bomb hourly request limit). Override this value if you want to send more requests per hour (not recommended) or less.
 
 Example using the optional arguments:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Giant Bomb API
 
-An unofficial ruby wrapper for the [Giantbomb API](http://api.giantbomb.com). An API that provides structured data about videogames. You should inform yourself about the endpoints at http://www.giantbomb.com/api/documentation .
+An unofficial ruby wrapper for the [Giantbomb API](https://www.giantbomb.com/api/). An API that provides structured data about videogames. You should inform yourself about the endpoints at http://www.giantbomb.com/api/documentation .
 
 This gem aims to provide access to most endpoints on the API. You'll be able to **search**, **filter** and page throught most of them. See further below on what is supported. 
 

--- a/giant_bomb_api.gemspec
+++ b/giant_bomb_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                      = "giant_bomb_api"
-  s.version                   = "0.5.2"
+  s.version                   = "0.5.3"
   s.default_executable        = "giantbomb"
 
   s.authors                   = ["Tim Adler"]

--- a/lib/giant_bomb_api/client.rb
+++ b/lib/giant_bomb_api/client.rb
@@ -8,7 +8,7 @@ module GiantBombApi
   class Client
     attr_accessor :api_key
 
-    API_URL = 'http://api.giantbomb.com'
+    API_URL = 'https://www.giantbomb.com/api/'.freeze
 
     def initialize(api_key: nil, options: {})
       @api_key = api_key

--- a/lib/giant_bomb_api/collection_resource.rb
+++ b/lib/giant_bomb_api/collection_resource.rb
@@ -70,7 +70,11 @@ module GiantBombApi
           request_time = t2 - t1
           time_to_one_hour = (started_at + 1.hour) - t2
           remaining_requests = rate_per_hour - num_of_requests
-          min_time_per_request = time_to_one_hour / remaining_requests
+          min_time_per_request = if remaining_requests == 0
+                                   time_to_one_hour
+                                 else
+                                   time_to_one_hour / remaining_requests
+                                 end
 
           sleep(min_time_per_request - request_time) if request_time < min_time_per_request
         end

--- a/lib/giant_bomb_api/collection_resource.rb
+++ b/lib/giant_bomb_api/collection_resource.rb
@@ -34,7 +34,7 @@ module GiantBombApi
       tries ||= (params[:tries] || 0)
 
       args = {}
-      args[:filter] = params.reject {|key,value| %i(sort limit offset).include?(key) }
+      args[:filter] = params.reject {|key,value| %i(sort limit offset tries).include?(key) }
       args[:sort] = sort if sort.present?
       args[:limit] = limit if limit.present?
       args[:offset] = offset if offset.present?


### PR DESCRIPTION
Hey @toadle, 2 more small changes. 😄 

- Updated to the new Giant Bomb API URL (see: https://www.giantbomb.com/forums/api-developers-3017/notice-apigiantbombcom-url-is-being-deprecated-in--1806651/#3)
- Added a `rate_per_hour` option to `each_page` that defaults to 200. I've had some problems with the GB API getting upset at me even when I've kept my requests at under 200/hour, so this just adds a bit more flexibility there.

EDIT: one other small change, I realized that my previous PR was adding the `tries` param to the filtering.